### PR TITLE
Fixed Dungeon Exit door in Hub not sending you to a valid scene.

### DIFF
--- a/Assets/Prefabs/Player/PlayerCore.cs
+++ b/Assets/Prefabs/Player/PlayerCore.cs
@@ -57,6 +57,13 @@ public class PlayerCore : MonoBehaviour
     [YarnCommand("enter_room")]
     private void EnterRoom(string roomName)
     {
-        SceneManager.LoadScene(roomName);
+        if (SceneUtility.GetBuildIndexByScenePath(roomName) >= 0)
+        {
+            SceneManager.LoadScene(roomName);
+        }
+        else
+        {
+            Debug.LogWarning("Scene " + roomName + " not in build.");
+        }
     }
 }

--- a/Assets/YS/Levels/Hub.yarn
+++ b/Assets/YS/Levels/Hub.yarn
@@ -9,7 +9,7 @@ position: 3,-71
 ---
 Dungeon Exit: Would you like to leave the dungeon?
 -> Yes
-    <<enter_room Player TalkingTest>>
+    <<enter_room Player IntroVOTest>>
 -> No
     <<stop>>
 ===


### PR DESCRIPTION
Also Added a check to see if the scene name is valid, as well as a warning when it isn't.